### PR TITLE
Use 'verification_uri_complete' for web browser

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -99,10 +99,7 @@ class EpicGenerator:
             print("Opening device code link in a new tab.")
 
             device_code = await self.create_device_code()
-            webbrowser.open(
-                f"https://www.epicgames.com/activate?userCode={device_code[0]}",
-                new=1,
-            )
+            webbrowser.open(device_code[0], new=1)
 
             user = await self.wait_for_device_code_completion(code=device_code[1])
             device_auths = await self.create_device_auths(user)
@@ -160,7 +157,7 @@ class EpicGenerator:
         ) as request:
             data = await request.json()
 
-        return data["user_code"], data["device_code"]
+        return data["verification_uri_complete"], data["device_code"]
 
     async def wait_for_device_code_completion(self, code: str) -> EpicUser:
         os.system('cls' if sys.platform.startswith('win') else 'clear')


### PR DESCRIPTION
The method `create_device_code` receives the following JSON

```json
{
    "user_code": "XXXXXX",
    "device_code": "XXXXXXXXXXXXXXXXXXXXXX",
    "verification_uri": "https://www.epicgames.com/activate",
    "verification_uri_complete": "https://www.epicgames.com/activate?userCode=XXXXXX",
    "prompt": "login",
    "expires_in": 600,
    "interval": 10,
    "client_id": "98f7e42c2e3a4f86a74eb43fbb41ed39"
}
```


The `verification_uri_complete` value contains the full URL so it doesn't have to be concatenated as `"https://www.epicgames.com/activate?userCode={device_code[0]}"`